### PR TITLE
Performance Improvements: Fix dynamic DoFObs and matrix multiply order in IESEKF update

### DIFF
--- a/include/Core/State.hpp
+++ b/include/Core/State.hpp
@@ -45,7 +45,8 @@ struct State {
   static constexpr int DoF = BundleT::DoF;  // DoF whole state
   static constexpr int DoFS2 = DoF-1;       // DoF g as S2
   static constexpr int DoFNoise = 4*3;      // b_w, b_a, n_{b_w}, n_{b_a}
-  static constexpr int DoFObs = manif::SGal3d::DoF + manif::SE3d::DoF;   // DoF obsevation equation
+  static constexpr int DoFObs_reduced = manif::SGal3d::DoF; // DoF obsevation equation (without extrinsics)
+  static constexpr int DoFObs_full = manif::SGal3d::DoF + manif::SE3d::DoF;   // DoF obsevation equation
 
   BundleT X;
   Mat<DoFS2> P;
@@ -55,8 +56,9 @@ struct State {
   Vec<3> a; // linear acceleration (IMU input)
 
   double stamp;
+  int DoFObs;
 
-  State() : stamp(-1.0) {};
+  State() : stamp(-1.0), DoFObs(DoFObs_full) {};
 
   void init() {
   
@@ -86,6 +88,8 @@ struct State {
     P.diagonal().segment(19, 3).setConstant(cfg.ikfom.covariance.initial_cov.accel_bias);
     P.diagonal().segment(22, 2).setConstant(cfg.ikfom.covariance.initial_cov.gravity);
 
+
+    DoFObs = cfg.ikfom.estimate_extrinsics ? DoFObs_full : DoFObs_reduced;
 
     w.setZero();
     a.setZero();
@@ -195,8 +199,8 @@ PROFC_NODE("update")
 // OBSERVATION MODEL
 
     auto h_model = [&](const State& s,
-                       Mat<Eigen::Dynamic, DoFObs>& H,
-                       Mat<Eigen::Dynamic, 1>&      z) {
+                       Eigen::MatrixXd& H,
+                       Mat<Eigen::Dynamic, 1>& z) {
 
       int N = cloud->size();
 
@@ -282,8 +286,8 @@ PROFC_NODE("update")
     BundleT    X_predicted = X;
     Mat<DoFS2> P_predicted = P;
 
-    Mat<Eigen::Dynamic, DoFObs> H;
-    Mat<Eigen::Dynamic, 1>      z;
+    Eigen::MatrixXd        H;
+    Mat<Eigen::Dynamic, 1> z;
     Mat<DoFS2> KH;
 
     double R = cfg.ikfom.lidar_noise;
@@ -305,19 +309,19 @@ PROFC_NODE("update")
         P = J_inv * P * J_inv.transpose(); // !! projection
 
       // Build K from blocks (numerical stability)
-        Mat<DoFObs> HTH = H.transpose() * H / R;
-        
+        Eigen::MatrixXd HTH = H.transpose() * H / R;
+
         Mat<DoFS2>  P_inv = P.inverse();
-        P_inv.template topLeftCorner<DoFObs, DoFObs>() += HTH;
+        P_inv.topLeftCorner(DoFObs, DoFObs) += HTH;
         P_inv = P_inv.inverse();
 
-        Vec<DoFS2> Kz = P_inv.template topLeftCorner<DoFS2, DoFObs>() * H.transpose() * z / R;
+        Vec<DoFS2> Kz = P_inv.topLeftCorner(DoFS2, DoFObs) * (H.transpose() * z) / R;
 
         KH.setZero();
-        KH.template topLeftCorner<DoFS2, DoFObs>() = P_inv.template topLeftCorner<DoFS2, DoFObs>() * HTH;
+        KH.topLeftCorner(DoFS2, DoFObs) = P_inv.topLeftCorner(DoFS2, DoFObs) * HTH;
 
-      dx = Kz + (KH - Mat<DoFS2>::Identity()) * J_inv * dx; 
-      
+      dx = Kz + (KH - Mat<DoFS2>::Identity()) * J_inv * dx;
+
       // Update manif Bundle, left g unmodified
       Tangent tau = Tangent::Zero();
       tau.coeffs().head(DoF-3) = dx.head(DoF-3);


### PR DESCRIPTION
KEY OVERVIEW:

- Improved state update time when extrinsics estimation is off
- Improved gain calcualtion order

Hi Carlos,
Thank you again for an amazing LIO project! I am a member of TUfast and have worked on our own custom modifications of the base code. We have integrated recent changes that were made here as well. I have noticed quite some performance impact and decided to dig a bit deeper with c++ profiling.

Performance impact can cause LiDAR callback to overlap and temporary steal the mutex causing a temporary cascading effect (this is why exclusive mutex callback type can help, but only if state update takes more time then gap between lidar update frames):
<img width="1239" height="955" alt="problem_of_lidar_mutex_stealing" src="https://github.com/user-attachments/assets/2c385795-c71b-40be-b899-bf9843f0a5d7" />


This could help also with performance issues at (https://github.com/CPerezRuiz335/LIMOncello/issues/18#issue-4174690615). But not sure. Even with these modifications we are getting more LiDAR timeouts as before, but for use the state estimation performance is still exceptional.


Some key things that seem to be causing more long state updates:
1.)  new State has 16 DoF compared to 10; this impacts the computation of H.transpose() * H ( O(rows * cols^2) in quadratic dependance, causing a 2.5x performance decrease on average. I have adapted the code to conditionally reduce the number of degrees of freedom if estimate extrinsics is false (which is usually recommened and default in all configs).

Results below.

Before:
<img width="521" height="800" alt="state_limoncello_source" src="https://github.com/user-attachments/assets/33a63faa-3922-4b40-983d-e033f5f288ee" />

After:
<img width="524" height="800" alt="state_limoncello_updated" src="https://github.com/user-attachments/assets/a38db4ec-ef26-46eb-a1fc-908b67a93cf0" />


2.) A minor change was also changing the order of computation of:
`Vec<DoFS2> Kz = P_inv.topLeftCorner(DoFS2, DoFObs) * (H.transpose() * z) / R;`

It improves that computations time by 10x, but that time is low any way so there is not larger performance impact.

Before:
<img width="508" height="799" alt="km_gain_apply_source" src="https://github.com/user-attachments/assets/e62caef7-1a61-4cf8-a78b-2fdbb3312146" />

After:
<img width="521" height="806" alt="km_gain_apply_changed" src="https://github.com/user-attachments/assets/78be8496-1fa5-4e2c-a72b-8e2dec4dc46b" />

As said we are using a heavily modified version currently so I tried to separately integrate those changes into your repository. I have build the version and briefly tested it, but it would probably be good to run some more tests.
